### PR TITLE
Fix wavelet tokenizer reconstruction and shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ You can load these models to generate images via the codes in [demo_sample.ipynb
 
 1. Install `torch>=2.0.0`.
 2. Install other pip packages via `pip3 install -r requirements.txt`.
-3. Prepare the [ImageNet](http://image-net.org/) dataset
+3. To enable the wavelet tokenizer, install `pytorch_wavelets` and its `pywavelets` dependency via `pip3 install pytorch_wavelets pywavelets`.
+4. Prepare the [ImageNet](http://image-net.org/) dataset
     <details>
     <summary> assume the ImageNet is in `/path/to/imagenet`. It should be like this:</summary>
 
@@ -126,6 +127,8 @@ You can load these models to generate images via the codes in [demo_sample.ipynb
 ## Training Scripts
 
 To train VAR-{d16, d20, d24, d30, d36-s} on ImageNet 256x256 or 512x512, you can run the following command:
+Add `--wavelet` to enable the DTCWT-based tokenizer. Use `--wlevels` and `--wvocab` to adjust decomposition levels and codebook size.
+When enabled, images are tokenized with multi-scale wavelet coefficients in place of the VQ-VAE encoder, leading to slightly different training dynamics and sampling behavior.
 ```shell
 # d16, 256x256
 torchrun --nproc_per_node=8 --nnodes=... --node_rank=... --master_addr=... --master_port=... train.py \

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 from .quant import VectorQuantizer2
 from .var import VAR
 from .vqvae import VQVAE
+from .wavelet_tokenizer import WaveletTokenizer
 
 
 def build_vae_var(

--- a/models/wavelet_tokenizer.py
+++ b/models/wavelet_tokenizer.py
@@ -1,0 +1,149 @@
+import math
+from typing import List, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from pytorch_wavelets import DTCWTForward, DTCWTInverse
+
+
+class EMAVQ(nn.Module):
+    """Simple EMA vector quantizer operating on quaternion tokens."""
+
+    def __init__(self, vocab_size: int, code_dim: int, decay: float = 0.99, eps: float = 1e-5):
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.code_dim = code_dim
+        self.decay = decay
+        self.eps = eps
+        self.embedding = nn.Embedding(vocab_size, code_dim)
+        nn.init.uniform_(self.embedding.weight, -1.0 / vocab_size, 1.0 / vocab_size)
+        self.register_buffer("ema_cluster_size", torch.zeros(vocab_size))
+        self.register_buffer("ema_weight", torch.zeros(vocab_size, code_dim))
+
+    def forward(self, feats: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Quantize input features.
+
+        Args:
+            feats: (B, L, D)
+        Returns:
+            quantized features, indices, vq loss
+        """
+        B, L, D = feats.shape
+        flat = feats.view(-1, D)
+        dist = (
+            flat.pow(2).sum(1, keepdim=True)
+            - 2 * flat @ self.embedding.weight.t()
+            + self.embedding.weight.pow(2).sum(1)
+        )
+        idx = dist.argmin(1)
+        quant = self.embedding(idx).view(B, L, D)
+
+        if self.training:
+            one_hot = F.one_hot(idx, self.vocab_size).type(flat.dtype)
+            self.ema_cluster_size.mul_(self.decay).add_(one_hot.sum(0), alpha=1 - self.decay)
+            self.ema_weight.mul_(self.decay).add_(one_hot.t() @ flat, alpha=1 - self.decay)
+            n = self.ema_cluster_size.sum()
+            cluster_size = (self.ema_cluster_size + self.eps) / (n + self.vocab_size * self.eps) * n
+            embed = self.ema_weight / cluster_size.unsqueeze(1)
+            self.embedding.weight.data.copy_(embed)
+
+        loss = F.mse_loss(quant.detach(), feats)
+        quant = feats + (quant - feats).detach()
+        return quant, idx.view(B, L), loss
+
+
+class WaveletTokenizer(nn.Module):
+    """Multi-scale wavelet tokenizer using quaternion VQ."""
+
+    def __init__(self, levels: int = 3, vocab_size: int = 4096):
+        super().__init__()
+        self.levels = levels
+        self.vq = EMAVQ(vocab_size, 4)
+        self.embedding = self.vq.embedding
+        self.dtcwt = DTCWTForward(J=levels, biort="near_sym_b", qshift="qshift_b")
+        self.itcwt = DTCWTInverse(biort="near_sym_b", qshift="qshift_b")
+        self.vocab_size = vocab_size
+        self.Cvae = 4  # quaternion dimension
+        class _Proxy:
+            def __init__(self, parent: 'WaveletTokenizer'):
+                self._parent = parent
+                self.embedding = parent.embedding
+
+            def idxBl_to_var_input(self, gt_ms_idx_Bl):
+                return self._parent.idxBl_to_var_input(gt_ms_idx_Bl)
+
+            def get_next_autoregressive_input(self, si, SN, f_hat, h_BChw):
+                return self._parent.get_next_autoregressive_input(si, SN, f_hat, h_BChw)
+
+        self.quantize = _Proxy(self)  # lightweight proxy for trainer compatibility
+        self.shapes: List[Tuple[int, int, int, int]] = []
+
+    @staticmethod
+    def _complex_to_quaternion(c: torch.Tensor) -> torch.Tensor:
+        real, imag = c[..., 0], c[..., 1]
+        amp = (real.pow(2) + imag.pow(2)).sqrt()
+        phase = torch.atan2(imag, real)
+        return torch.stack((real, imag, amp, phase), dim=-1)
+
+    @staticmethod
+    def _quaternion_to_complex(q: torch.Tensor) -> torch.Tensor:
+        real = q[..., 0]
+        imag = q[..., 1]
+        return torch.stack((real, imag), dim=-1)
+
+    def img_to_idxBl(self, img: torch.Tensor) -> List[torch.Tensor]:
+        """Decompose image and quantize to token indices."""
+        yl, yh = self.dtcwt(img)
+        self.shapes = []
+        idx_ls: List[torch.Tensor] = []
+        for h in yh:
+            B, C, O, H, W, _ = h.shape
+            self.shapes.append((C, O, H, W))
+            q = (
+                self._complex_to_quaternion(h)
+                .permute(0, 3, 4, 2, 1, 5)  # B H W O C 4
+                .reshape(B, -1, 4)
+            )
+            _, idx, _ = self.vq(q)
+            idx_ls.append(idx)
+        B, C, H, W = yl.shape
+        self.shapes.append((C, 1, H, W))
+        amp = yl.abs()
+        low = torch.stack(
+            (yl, torch.zeros_like(yl), amp, torch.zeros_like(yl)),
+            dim=-1,
+        )  # B C H W 4
+        _, idx, _ = self.vq(low.permute(0, 2, 3, 1, 4).reshape(B, -1, 4))
+        idx_ls.append(idx)
+        return idx_ls
+
+    def idxBl_to_img(self, ms_idx_Bl: List[torch.Tensor]) -> torch.Tensor:
+        """Decode tokens back to image."""
+        yh = []
+        for i, idx in enumerate(ms_idx_Bl[:-1]):
+            C, O, H, W = self.shapes[i]
+            q = (
+                self.embedding(idx)
+                .view(idx.shape[0], H, W, O, C, 4)  # B H W O C 4
+                .permute(0, 4, 3, 1, 2, 5)
+            )
+            c = self._quaternion_to_complex(q)
+            yh.append(c)
+        C, _, H, W = self.shapes[-1]
+        q_low = (
+            self.embedding(ms_idx_Bl[-1])
+            .view(ms_idx_Bl[-1].shape[0], H, W, C, 4)
+            .permute(0, 3, 1, 2, 4)
+        )
+        yl = q_low[..., 0]
+        img = self.itcwt((yl, yh))
+        return img.clamp(-1, 1)
+
+    # ===== functions used by VAR trainer =====
+    def idxBl_to_var_input(self, gt_ms_idx_Bl: List[torch.Tensor]) -> torch.Tensor:
+        feats = [self.embedding(idx) for idx in gt_ms_idx_Bl[:-1]]
+        return torch.cat(feats, dim=1) if feats else None
+
+    def get_next_autoregressive_input(self, si: int, SN: int, f_hat: torch.Tensor, h_BChw: torch.Tensor):
+        return None, h_BChw

--- a/utils/arg_util.py
+++ b/utils/arg_util.py
@@ -63,6 +63,11 @@ class Args(Tap):
     saln: bool = False      # whether to use shared adaln
     anorm: bool = True      # whether to use L2 normalized attention
     fuse: bool = True       # whether to use fused op like flash attn, xformers, fused MLP, fused LayerNorm, etc.
+
+    # wavelet tokenizer
+    wavelet: bool = False   # enable wavelet tokenizer
+    wlevels: int = 3        # number of wavelet decomposition levels
+    wvocab: int = 4096      # wavelet codebook size
     
     # data
     pn: str = '1_2_3_4_5_6_8_10_13_16'
@@ -76,7 +81,7 @@ class Args(Tap):
     workers: int = 0        # num workers; 0: auto, -1: don't use multiprocessing in DataLoader
     
     # progressive training
-    pg: float = 0.0         # >0 for use progressive training during [0%, this] of training
+    pg: float = 0.0         # >0 for use progressive training during [0%%, this] of training
     pg0: int = 4            # progressive initial stage, 0: from the 1st token map, 1: from the 2nd token map, etc
     pgwp: float = 0         # num of warmup epochs at each progressive stage
     


### PR DESCRIPTION
## Summary
- ensure quaternion quantization uses real/imag channels
- store orientation in `shapes` and handle lowpass amplitude
- fix tensor reshaping with explicit batch size

## Testing
- `python -m py_compile models/wavelet_tokenizer.py models/var.py train.py utils/arg_util.py models/__init__.py`
- ❌ `python - <<'EOF'
import torch
from models.wavelet_tokenizer import WaveletTokenizer
wt = WaveletTokenizer(levels=2, vocab_size=16)
wt.eval()
img = torch.randn(1,3,32,32)
idxs = wt.img_to_idxBl(img)
img_rec = wt.idxBl_to_img(idxs)
print('idx lens', [i.shape for i in idxs])
print('recon mean', img_rec.mean().item())
EOF`
  (failed to import `torch`)


------
https://chatgpt.com/codex/tasks/task_e_6857a0d7bdc083249f159e50abe52984