### PR TITLE
fix(tokenizer): close amplitude-phase loop & harden multi-GPU safety

### DIFF
--- a/models/var.py
+++ b/models/var.py
@@ -201,7 +201,11 @@ class VAR(nn.Module):
         if not self.use_wavelet:
             return self.vae_proxy[0].fhat_to_img(f_hat).add_(1).mul_(0.5)
         else:
-            return self.vae_proxy[0].idxBl_to_img(ms_idx).add_(1).mul_(0.5)
+            if not hasattr(self, '_wavelet_shapes'):
+                img_size = self.patch_nums[-1] * 16
+                dummy = torch.zeros(1, 3, img_size, img_size, device=self.lvl_1L.device)
+                _, self._wavelet_shapes = self.vae_proxy[0].img_to_idxBl(dummy)
+            return self.vae_proxy[0].idxBl_to_img(ms_idx, self._wavelet_shapes).add_(1).mul_(0.5)
     
     def forward(self, label_B: torch.LongTensor, x_BLCv_wo_first_l: torch.Tensor) -> torch.Tensor:  # returns logits_BLV
         """

--- a/trainer.py
+++ b/trainer.py
@@ -63,7 +63,7 @@ class VARTrainer(object):
             inp_B3HW = inp_B3HW.to(dist.get_device(), non_blocking=True)
             label_B = label_B.to(dist.get_device(), non_blocking=True)
             
-            gt_idx_Bl: List[ITen] = self.vae_local.img_to_idxBl(inp_B3HW)
+            gt_idx_Bl, _ = self.vae_local.img_to_idxBl(inp_B3HW)
             gt_BL = torch.cat(gt_idx_Bl, dim=1)
             x_BLCv_wo_first_l: Ten = self.quantize_local.idxBl_to_var_input(gt_idx_Bl)
             
@@ -102,7 +102,7 @@ class VARTrainer(object):
         B, V = label_B.shape[0], self.vae_local.vocab_size
         self.var.require_backward_grad_sync = stepping
         
-        gt_idx_Bl: List[ITen] = self.vae_local.img_to_idxBl(inp_B3HW)
+        gt_idx_Bl, _ = self.vae_local.img_to_idxBl(inp_B3HW)
         gt_BL = torch.cat(gt_idx_Bl, dim=1)
         x_BLCv_wo_first_l: Ten = self.quantize_local.idxBl_to_var_input(gt_idx_Bl)
         


### PR DESCRIPTION
## Summary
- refactor EMAVQ and WaveletTokenizer to use amplitude/phase tokens instead of quaternion tokens
- return `shapes` from `img_to_idxBl` for thread-safety
- remove `.to(device)` calls and use `.reshape` for safety
- adapt trainer and VAR sampling to new tokenizer API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857bc6e0c0c8324a8c0da521f12ac39