### PR TITLE
Normalize wavelet amplitudes before VQ

### DIFF
--- a/models/var.py
+++ b/models/var.py
@@ -204,8 +204,8 @@ class VAR(nn.Module):
             if not hasattr(self, '_wavelet_shapes'):
                 img_size = self.patch_nums[-1] * 16
                 dummy = torch.zeros(1, 3, img_size, img_size, device=self.lvl_1L.device)
-                _, self._wavelet_shapes = self.vae_proxy[0].img_to_idxBl(dummy)
-            return self.vae_proxy[0].idxBl_to_img(ms_idx, self._wavelet_shapes).add_(1).mul_(0.5)
+                _, self._wavelet_shapes, self._wavelet_stats = self.vae_proxy[0].img_to_idxBl(dummy)
+            return self.vae_proxy[0].idxBl_to_img(ms_idx, self._wavelet_shapes, getattr(self, '_wavelet_stats', None)).add_(1).mul_(0.5)
     
     def forward(self, label_B: torch.LongTensor, x_BLCv_wo_first_l: torch.Tensor) -> torch.Tensor:  # returns logits_BLV
         """

--- a/trainer.py
+++ b/trainer.py
@@ -63,7 +63,7 @@ class VARTrainer(object):
             inp_B3HW = inp_B3HW.to(dist.get_device(), non_blocking=True)
             label_B = label_B.to(dist.get_device(), non_blocking=True)
             
-            gt_idx_Bl, _ = self.vae_local.img_to_idxBl(inp_B3HW)
+            gt_idx_Bl, _, _ = self.vae_local.img_to_idxBl(inp_B3HW)
             gt_BL = torch.cat(gt_idx_Bl, dim=1)
             x_BLCv_wo_first_l: Ten = self.quantize_local.idxBl_to_var_input(gt_idx_Bl)
             
@@ -102,7 +102,7 @@ class VARTrainer(object):
         B, V = label_B.shape[0], self.vae_local.vocab_size
         self.var.require_backward_grad_sync = stepping
         
-        gt_idx_Bl, _ = self.vae_local.img_to_idxBl(inp_B3HW)
+        gt_idx_Bl, _, _ = self.vae_local.img_to_idxBl(inp_B3HW)
         gt_BL = torch.cat(gt_idx_Bl, dim=1)
         x_BLCv_wo_first_l: Ten = self.quantize_local.idxBl_to_var_input(gt_idx_Bl)
         


### PR DESCRIPTION
## Summary
- compute mean and std for each wavelet decomposition level
- normalize amplitudes using the statistics and optionally learn per-level scales
- store stats for decoding and apply inverse normalization
- adjust VAR and trainer to new API

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: No matching distribution found for torch~=2.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_6857c813dd9c8324b49cb7ad84938c02