### PR TITLE
Add wavelet patch configuration

### DIFF
--- a/models/var.py
+++ b/models/var.py
@@ -28,6 +28,7 @@ class VAR(nn.Module):
         patch_nums=(1, 2, 3, 4, 5, 6, 8, 10, 13, 16),   # 10 steps by default
         flash_if_available=True, fused_if_available=True,
         use_wavelet=False, wavelet_levels=3, wavelet_vocab=4096,
+        wavelet_patch_nums=None,
     ):
         super().__init__()
         # 0. hyperparameters
@@ -38,7 +39,13 @@ class VAR(nn.Module):
         self.cond_drop_rate = cond_drop_rate
         self.prog_si = -1   # progressive training
         
-        self.patch_nums: Tuple[int] = patch_nums
+        self.patch_nums: Tuple[int]
+        if use_wavelet and wavelet_patch_nums is not None:
+            self.patch_nums = tuple(wavelet_patch_nums)
+            if hasattr(vae_local, 'patch_nums'):
+                vae_local.patch_nums = self.patch_nums
+        else:
+            self.patch_nums = patch_nums
         self.L = sum(pn ** 2 for pn in self.patch_nums)
         self.first_l = self.patch_nums[0] ** 2
         self.begin_ends = []

--- a/models/wavelet_tokenizer.py
+++ b/models/wavelet_tokenizer.py
@@ -57,7 +57,7 @@ class EMAVQ(nn.Module):
 class WaveletTokenizer(nn.Module):
     """Multi-scale wavelet tokenizer using amplitude/cos/sin VQ."""
 
-    def __init__(self, levels: int = 3, vocab_size: int = 4096):
+    def __init__(self, levels: int = 3, vocab_size: int = 4096, patch_nums=None):
         super().__init__()
         self.levels = levels
         self.vq = EMAVQ(vocab_size, 3)   # amp + cosφ + sinφ
@@ -66,6 +66,7 @@ class WaveletTokenizer(nn.Module):
         self.itcwt = DTCWTInverse(biort="near_sym_b", qshift="qshift_b")
         self.vocab_size = vocab_size
         self.Cvae = 3  # amp, cosφ, sinφ
+        self.patch_nums = patch_nums
         class _Proxy:
             def __init__(self, parent: 'WaveletTokenizer'):
                 self._parent = parent
@@ -100,6 +101,23 @@ class WaveletTokenizer(nn.Module):
         real = amp * cos
         imag = amp * sin
         return torch.stack((real, imag), dim=-1)
+
+    def calc_token_lens(self, image_size: int, subsample: int = 1) -> List[int]:
+        """Return token lengths for each level given image size and subsampling."""
+        with torch.no_grad():
+            dummy = torch.zeros(1, 3, image_size, image_size, device=self.embedding.weight.device)
+            yl, yh = self.dtcwt(dummy)
+        lens: List[int] = []
+        for h in yh:
+            _, C, O, H, W, _ = h.shape
+            H = math.ceil(H / subsample)
+            W = math.ceil(W / subsample)
+            lens.append(C * O * H * W)
+        C, H, W = yl.shape[1:]
+        H = math.ceil(H / subsample)
+        W = math.ceil(W / subsample)
+        lens.append(C * H * W)
+        return lens
 
     def img_to_idxBl(self, img: torch.Tensor) -> Tuple[List[torch.Tensor], List[Tuple[int, int, int, int]]]:
         """Decompose image and quantize to token indices."""
@@ -151,7 +169,14 @@ class WaveletTokenizer(nn.Module):
 
     # ===== functions used by VAR trainer =====
     def idxBl_to_var_input(self, gt_ms_idx_Bl: List[torch.Tensor]) -> torch.Tensor:
-        feats = [self.embedding(idx) for idx in gt_ms_idx_Bl[:-1]]
+        feats = []
+        for si, idx in enumerate(gt_ms_idx_Bl[:-1]):
+            emb = self.embedding(idx)
+            if self.patch_nums is not None and si + 1 < len(self.patch_nums):
+                tgt = self.patch_nums[si + 1] ** 2
+                if emb.shape[1] != tgt:
+                    emb = F.interpolate(emb.transpose(1, 2), size=tgt, mode='linear', align_corners=False).transpose(1, 2)
+            feats.append(emb)
         return torch.cat(feats, dim=1) if feats else None
 
     def get_next_autoregressive_input(self, si: int, SN: int, f_hat: torch.Tensor, h_BChw: torch.Tensor):

--- a/train.py
+++ b/train.py
@@ -83,15 +83,16 @@ def build_everything(args: arg_util.Args):
     from utils.lr_control import filter_params
     
     if args.wavelet:
-        vae_local = WaveletTokenizer(levels=args.wlevels, vocab_size=args.wvocab)
+        vae_local = WaveletTokenizer(levels=args.wlevels, vocab_size=args.wvocab, patch_nums=args.wavelet_patch_nums)
         var_wo_ddp = VAR(
             vae_local=vae_local,
             num_classes=num_classes, depth=args.depth, embed_dim=args.depth * 64,
             num_heads=args.depth, mlp_ratio=4., drop_rate=0., attn_drop_rate=0., drop_path_rate=0.1 * args.depth / 24,
             norm_eps=1e-6, shared_aln=args.saln, cond_drop_rate=0.1,
-            attn_l2_norm=args.anorm, patch_nums=args.patch_nums,
+            attn_l2_norm=args.anorm, patch_nums=args.wavelet_patch_nums,
             flash_if_available=args.fuse, fused_if_available=args.fuse,
             use_wavelet=True, wavelet_levels=args.wlevels, wavelet_vocab=args.wvocab,
+            wavelet_patch_nums=args.wavelet_patch_nums,
         )
         vae_local = args.compile_model(vae_local, args.vfast)
         var_wo_ddp = args.compile_model(var_wo_ddp, args.tfast)

--- a/utils/arg_util.py
+++ b/utils/arg_util.py
@@ -68,6 +68,7 @@ class Args(Tap):
     wavelet: bool = False   # enable wavelet tokenizer
     wlevels: int = 3        # number of wavelet decomposition levels
     wvocab: int = 4096      # wavelet codebook size
+    wpatch: str = ''        # wavelet patch numbers
     
     # data
     pn: str = '1_2_3_4_5_6_8_10_13_16'
@@ -252,9 +253,20 @@ def init_dist_and_get_args():
         args.pn = '1_2_3_4_6_9_13_18_24_32'
     elif args.pn == '1024':
         args.pn = '1_2_3_4_5_7_9_12_16_21_27_36_48_64'
+
     args.patch_nums = tuple(map(int, args.pn.replace('-', '_').split('_')))
     args.resos = tuple(pn * args.patch_size for pn in args.patch_nums)
     args.data_load_reso = max(args.resos)
+
+    if args.wpatch:
+        args.wavelet_patch_nums = tuple(map(int, args.wpatch.replace('-', '_').split('_')))
+    else:
+        args.wavelet_patch_nums = args.patch_nums
+
+    if args.wavelet:
+        args.patch_nums = args.wavelet_patch_nums
+        args.resos = tuple(pn * args.patch_size for pn in args.patch_nums)
+        args.data_load_reso = max(args.resos)
     
     # update args: bs and lr
     bs_per_gpu = round(args.bs / args.ac / dist.get_world_size())


### PR DESCRIPTION
## Summary
- add patch size parameter to `WaveletTokenizer`
- compute token lengths per level via new helper
- support `wavelet_patch_nums` in VAR and trainer
- expose `--wpatch` argument in parser

## Testing
- `python -m py_compile models/var.py models/wavelet_tokenizer.py train.py utils/arg_util.py`

------
https://chatgpt.com/codex/tasks/task_e_6857c81080d88324a87436abcca9b898