### PR TITLE
Improve wavelet tokenizer

### DIFF
--- a/models/var.py
+++ b/models/var.py
@@ -27,7 +27,7 @@ class VAR(nn.Module):
         attn_l2_norm=False,
         patch_nums=(1, 2, 3, 4, 5, 6, 8, 10, 13, 16),   # 10 steps by default
         flash_if_available=True, fused_if_available=True,
-        use_wavelet=False, wavelet_levels=3, wavelet_vocab=4096,
+        use_wavelet=False, wavelet_levels=3, wavelet_vocab=4096, wavelet_patch_nums=None,
     ):
         super().__init__()
         # 0. hyperparameters
@@ -38,6 +38,9 @@ class VAR(nn.Module):
         self.cond_drop_rate = cond_drop_rate
         self.prog_si = -1   # progressive training
         
+        if use_wavelet and wavelet_patch_nums is not None:
+            patch_nums = tuple(wavelet_patch_nums)
+            vae_local.patch_nums = patch_nums
         self.patch_nums: Tuple[int] = patch_nums
         self.L = sum(pn ** 2 for pn in self.patch_nums)
         self.first_l = self.patch_nums[0] ** 2
@@ -157,7 +160,7 @@ class VAR(nn.Module):
         next_token_map = sos.unsqueeze(1).expand(2 * B, self.first_l, -1) + self.pos_start.expand(2 * B, self.first_l, -1) + lvl_pos[:, :self.first_l]
 
         cur_L = 0
-        f_hat = sos.new_zeros(B, self.Cvae, self.patch_nums[-1], self.patch_nums[-1]) if not self.use_wavelet else None
+        f_hat = sos.new_zeros(B, self.Cvae, self.patch_nums[-1], self.patch_nums[-1])
         ms_idx = []
         
         for b in self.blocks: b.attn.kv_caching(True)
@@ -178,24 +181,21 @@ class VAR(nn.Module):
             
             idx_Bl = sample_with_top_k_top_p_(logits_BlV, rng=rng, top_k=top_k, top_p=top_p, num_samples=1)[:, :, 0]
             ms_idx.append(idx_Bl)
-            if not self.use_wavelet:
-                if not more_smooth:
-                    h_BChw = self.vae_quant_proxy[0].embedding(idx_Bl)
-                else:
-                    gum_t = max(0.27 * (1 - ratio * 0.95), 0.005)
-                    h_BChw = gumbel_softmax_with_rng(logits_BlV.mul(1 + ratio), tau=gum_t, hard=False, dim=-1, rng=rng) @ self.vae_quant_proxy[0].embedding.weight.unsqueeze(0)
-
-                h_BChw = h_BChw.transpose_(1, 2).reshape(B, self.Cvae, pn, pn)
-                f_hat, next_token_map = self.vae_quant_proxy[0].get_next_autoregressive_input(si, len(self.patch_nums), f_hat, h_BChw)
-                if si != self.num_stages_minus_1:
-                    next_token_map = next_token_map.view(B, self.Cvae, -1).transpose(1, 2)
-                    next_token_map = self.word_embed(next_token_map) + lvl_pos[:, cur_L:cur_L + self.patch_nums[si+1] ** 2]
-                    next_token_map = next_token_map.repeat(2, 1, 1)
+            if not more_smooth:
+                h_BChw = self.vae_quant_proxy[0].embedding(idx_Bl)
             else:
-                if si != self.num_stages_minus_1:
-                    next_token_map = self.word_embed(self.vae_quant_proxy[0].embedding(idx_Bl))
-                    next_token_map = next_token_map + lvl_pos[:, cur_L:cur_L + self.patch_nums[si+1] ** 2]
-                    next_token_map = next_token_map.repeat(2, 1, 1)
+                gum_t = max(0.27 * (1 - ratio * 0.95), 0.005)
+                h_BChw = gumbel_softmax_with_rng(logits_BlV.mul(1 + ratio), tau=gum_t, hard=False, dim=-1, rng=rng) @ self.vae_quant_proxy[0].embedding.weight.unsqueeze(0)
+
+            if h_BChw.shape[1] != pn * pn:
+                h_BChw = F.interpolate(h_BChw.transpose(1, 2), size=pn * pn, mode='linear', align_corners=False).transpose(1, 2)
+
+            h_BChw = h_BChw.transpose_(1, 2).reshape(B, self.Cvae, pn, pn)
+            f_hat, next_token_map = self.vae_quant_proxy[0].get_next_autoregressive_input(si, len(self.patch_nums), f_hat, h_BChw)
+            if si != self.num_stages_minus_1:
+                next_token_map = next_token_map.view(B, self.Cvae, -1).transpose(1, 2)
+                next_token_map = self.word_embed(next_token_map) + lvl_pos[:, cur_L:cur_L + self.patch_nums[si+1] ** 2]
+                next_token_map = next_token_map.repeat(2, 1, 1)
         
         for b in self.blocks: b.attn.kv_caching(False)
         if not self.use_wavelet:

--- a/models/wavelet_tokenizer.py
+++ b/models/wavelet_tokenizer.py
@@ -57,7 +57,7 @@ class EMAVQ(nn.Module):
 class WaveletTokenizer(nn.Module):
     """Multi-scale wavelet tokenizer using amplitude/cos/sin VQ."""
 
-    def __init__(self, levels: int = 3, vocab_size: int = 4096):
+    def __init__(self, levels: int = 3, vocab_size: int = 4096, patch_nums: Tuple[int, ...] = None):
         super().__init__()
         self.levels = levels
         self.vq = EMAVQ(vocab_size, 3)   # amp + cosφ + sinφ
@@ -66,6 +66,10 @@ class WaveletTokenizer(nn.Module):
         self.itcwt = DTCWTInverse(biort="near_sym_b", qshift="qshift_b")
         self.vocab_size = vocab_size
         self.Cvae = 3  # amp, cosφ, sinφ
+        self.patch_nums = patch_nums
+        self.register_buffer('amp_mu', torch.zeros(levels))
+        self.register_buffer('amp_std', torch.ones(levels))
+        self.amp_scale = nn.Parameter(torch.ones(levels))
         class _Proxy:
             def __init__(self, parent: 'WaveletTokenizer'):
                 self._parent = parent
@@ -101,25 +105,54 @@ class WaveletTokenizer(nn.Module):
         imag = amp * sin
         return torch.stack((real, imag), dim=-1)
 
+    def compute_token_lens(self, img_size: int, subsample: int = 1) -> List[int]:
+        """Infer per-level token lengths for a given image size."""
+        with torch.no_grad():
+            dummy = torch.zeros(1, 3, img_size, img_size, device=self.embedding.weight.device)
+            yl, yh = self.dtcwt(dummy)
+            lens = []
+            for h in yh:
+                B, C, O, H, W, _ = h.shape
+                lens.append((C * O * H * W) // subsample)
+            B, C, H, W = yl.shape
+            lens.append((C * H * W) // subsample)
+        return lens
+
     def img_to_idxBl(self, img: torch.Tensor) -> Tuple[List[torch.Tensor], List[Tuple[int, int, int, int]]]:
         """Decompose image and quantize to token indices."""
         yl, yh = self.dtcwt(img)
         shapes_local: List[Tuple[int, int, int, int]] = []
         idx_ls: List[torch.Tensor] = []
-        for h in yh:
+        for li, h in enumerate(yh):
             B, C, O, H, W, _ = h.shape
             shapes_local.append((C, O, H, W))
-            q = (
-                self._complex_to_acs(h)
-                .permute(0, 3, 4, 2, 1, 5)  # B H W O C 3
-                .reshape(B, -1, 3)
-            )
+            acs = self._complex_to_acs(h)
+            amp = acs[..., 0]
+            mu = amp.mean()
+            std = amp.std() + 1e-8
+            if self.training:
+                self.amp_mu[li] = self.amp_mu[li] * 0.99 + mu * 0.01
+                self.amp_std[li] = self.amp_std[li] * 0.99 + std * 0.01
+            else:
+                mu, std = self.amp_mu[li], self.amp_std[li]
+            acs[..., 0] = (amp - mu) / std * self.amp_scale[li]
+            q = acs.permute(0, 3, 4, 2, 1, 5).reshape(B, -1, 3)
             _, idx, _ = self.vq(q)
             idx_ls.append(idx)
         B, C, H, W = yl.shape
         shapes_local.append((C, 1, H, W))
         low_c = torch.stack((yl, torch.zeros_like(yl)), dim=-1)
         low = self._complex_to_acs(low_c).unsqueeze(2)
+        amp = low[..., 0]
+        mu = amp.mean()
+        std = amp.std() + 1e-8
+        li = len(yh)
+        if self.training:
+            self.amp_mu[li] = self.amp_mu[li] * 0.99 + mu * 0.01
+            self.amp_std[li] = self.amp_std[li] * 0.99 + std * 0.01
+        else:
+            mu, std = self.amp_mu[li], self.amp_std[li]
+        low[..., 0] = (amp - mu) / std * self.amp_scale[li]
         _, idx, _ = self.vq(low.permute(0, 3, 4, 2, 1, 5).reshape(B, -1, 3))
         idx_ls.append(idx)
         return idx_ls, shapes_local
@@ -134,7 +167,11 @@ class WaveletTokenizer(nn.Module):
                 self.embedding(idx)
                 .reshape(B, H, W, O, C, 3)
                 .permute(0, 4, 3, 1, 2, 5)
-        )
+            )
+            amp = ap[..., 0]
+            amp = amp / self.amp_scale[i]
+            amp = amp * self.amp_std[i] + self.amp_mu[i]
+            ap = torch.stack((amp, ap[..., 1], ap[..., 2]), dim=-1)
             c = self._acs_to_complex(ap)
             yh.append(c)
         C, _, H, W = shapes[-1]
@@ -144,6 +181,10 @@ class WaveletTokenizer(nn.Module):
             .reshape(B, H, W, 1, C, 3)
             .permute(0, 4, 3, 1, 2, 5)
         )
+        amp = ap_low[..., 0]
+        amp = amp / self.amp_scale[len(shapes)-1]
+        amp = amp * self.amp_std[len(shapes)-1] + self.amp_mu[len(shapes)-1]
+        ap_low = torch.stack((amp, ap_low[...,1], ap_low[...,2]), dim=-1)
         yl = self._acs_to_complex(ap_low)[..., 0]
         yl = yl.squeeze(2)
         img = self.itcwt((yl, yh))
@@ -151,8 +192,25 @@ class WaveletTokenizer(nn.Module):
 
     # ===== functions used by VAR trainer =====
     def idxBl_to_var_input(self, gt_ms_idx_Bl: List[torch.Tensor]) -> torch.Tensor:
-        feats = [self.embedding(idx) for idx in gt_ms_idx_Bl[:-1]]
+        feats = []
+        if self.patch_nums is None:
+            feats = [self.embedding(idx) for idx in gt_ms_idx_Bl[:-1]]
+        else:
+            for idx, pn in zip(gt_ms_idx_Bl[:-1], self.patch_nums[:-1]):
+                f = self.embedding(idx)
+                if f.shape[1] != pn * pn:
+                    f = F.interpolate(f.transpose(1, 2), size=pn * pn, mode='linear', align_corners=False).transpose(1, 2)
+                feats.append(f)
         return torch.cat(feats, dim=1) if feats else None
 
     def get_next_autoregressive_input(self, si: int, SN: int, f_hat: torch.Tensor, h_BChw: torch.Tensor):
-        return None, h_BChw
+        if f_hat is None:
+            return None, h_BChw
+        HW = f_hat.shape[-1]
+        if si != SN - 1:
+            up = F.interpolate(h_BChw, size=(HW, HW), mode='bicubic')
+            f_hat.add_(up)
+            return f_hat, F.interpolate(f_hat, size=(self.patch_nums[si+1], self.patch_nums[si+1]), mode='area')
+        else:
+            f_hat.add_(F.interpolate(h_BChw, size=(HW, HW), mode='bicubic'))
+            return f_hat, f_hat

--- a/train.py
+++ b/train.py
@@ -83,7 +83,7 @@ def build_everything(args: arg_util.Args):
     from utils.lr_control import filter_params
     
     if args.wavelet:
-        vae_local = WaveletTokenizer(levels=args.wlevels, vocab_size=args.wvocab)
+        vae_local = WaveletTokenizer(levels=args.wlevels, vocab_size=args.wvocab, patch_nums=args.wavelet_patch_nums)
         var_wo_ddp = VAR(
             vae_local=vae_local,
             num_classes=num_classes, depth=args.depth, embed_dim=args.depth * 64,
@@ -91,7 +91,7 @@ def build_everything(args: arg_util.Args):
             norm_eps=1e-6, shared_aln=args.saln, cond_drop_rate=0.1,
             attn_l2_norm=args.anorm, patch_nums=args.patch_nums,
             flash_if_available=args.fuse, fused_if_available=args.fuse,
-            use_wavelet=True, wavelet_levels=args.wlevels, wavelet_vocab=args.wvocab,
+            use_wavelet=True, wavelet_levels=args.wlevels, wavelet_vocab=args.wvocab, wavelet_patch_nums=args.wavelet_patch_nums,
         )
         vae_local = args.compile_model(vae_local, args.vfast)
         var_wo_ddp = args.compile_model(var_wo_ddp, args.tfast)

--- a/utils/arg_util.py
+++ b/utils/arg_util.py
@@ -68,6 +68,8 @@ class Args(Tap):
     wavelet: bool = False   # enable wavelet tokenizer
     wlevels: int = 3        # number of wavelet decomposition levels
     wvocab: int = 4096      # wavelet codebook size
+    wpatch: str = ''        # wavelet patch nums, e.g. '64_16_4'
+    wavelet_patch_nums: tuple = None  # [automatically set]
     
     # data
     pn: str = '1_2_3_4_5_6_8_10_13_16'
@@ -255,6 +257,8 @@ def init_dist_and_get_args():
     args.patch_nums = tuple(map(int, args.pn.replace('-', '_').split('_')))
     args.resos = tuple(pn * args.patch_size for pn in args.patch_nums)
     args.data_load_reso = max(args.resos)
+    if args.wpatch:
+        args.wavelet_patch_nums = tuple(map(int, args.wpatch.replace('-', '_').split('_')))
     
     # update args: bs and lr
     bs_per_gpu = round(args.bs / args.ac / dist.get_world_size())


### PR DESCRIPTION
## Summary
- normalize wavelet amplitudes per level
- allow patch configuration for wavelet tokenizer
- add token length inference helper
- enable residual accumulation in wavelet mode
- expose `--wpatch` argument

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6857c57d39cc83248a052fb40f77a8a0