### PR TITLE
Fix wavelet tokenizer defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ You can load these models to generate images via the codes in [demo_sample.ipynb
 To train VAR-{d16, d20, d24, d30, d36-s} on ImageNet 256x256 or 512x512, you can run the following command:
 Add `--wavelet` to enable the DTCWT-based tokenizer. Use `--wlevels` and `--wvocab` to adjust decomposition levels and codebook size.
 When enabled, images are tokenized with multi-scale wavelet coefficients in place of the VQ-VAE encoder, leading to slightly different training dynamics and sampling behavior.
+If wavelet mode is used, specify patch counts for each level with `--wpatch`.  The number of values should be `wlevels + 1`.  For example, `--wpatch=2_4_8_16` works for `--wlevels=3`.  When omitted, the values are derived automatically from the final resolution.
 ```shell
 # d16, 256x256
 torchrun --nproc_per_node=8 --nnodes=... --node_rank=... --master_addr=... --master_port=... train.py \

--- a/models/wavelet_tokenizer.py
+++ b/models/wavelet_tokenizer.py
@@ -66,6 +66,14 @@ class WaveletTokenizer(nn.Module):
         self.itcwt = DTCWTInverse(biort="near_sym_b", qshift="qshift_b")
         self.vocab_size = vocab_size
         self.Cvae = 3  # amp, cosφ, sinφ
+        if patch_nums is None:
+            raise ValueError(
+                "WaveletTokenizer requires `patch_nums` (provide via --wpatch)."
+            )
+        if len(patch_nums) != levels + 1:
+            raise ValueError(
+                f"patch_nums length {len(patch_nums)} must equal levels+1={levels+1}"
+            )
         self.patch_nums = patch_nums
         self.register_buffer('amp_mu', torch.zeros(levels))
         self.register_buffer('amp_std', torch.ones(levels))

--- a/utils/arg_util.py
+++ b/utils/arg_util.py
@@ -257,7 +257,13 @@ def init_dist_and_get_args():
     args.patch_nums = tuple(map(int, args.pn.replace('-', '_').split('_')))
     args.resos = tuple(pn * args.patch_size for pn in args.patch_nums)
     args.data_load_reso = max(args.resos)
-    if args.wpatch:
+    if args.wavelet and not args.wpatch:
+        final_pn = args.patch_nums[-1]
+        args.wavelet_patch_nums = tuple(
+            max(1, final_pn // (2 ** i)) for i in range(args.wlevels, -1, -1)
+        )
+        print(f'[args] wpatch not provided; using {args.wavelet_patch_nums}')
+    elif args.wpatch:
         args.wavelet_patch_nums = tuple(map(int, args.wpatch.replace('-', '_').split('_')))
     
     # update args: bs and lr


### PR DESCRIPTION
## Summary
- handle missing `--wpatch` on the command line by deriving patch counts
- validate patch count length inside `WaveletTokenizer`
- document `--wpatch` usage in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857d2de18e48324975f4ed0118f4e97